### PR TITLE
Switch from find to globpath

### DIFF
--- a/autoload/ctrlp/controllers.vim
+++ b/autoload/ctrlp/controllers.vim
@@ -18,11 +18,11 @@ else
 endif
 
 function! ctrlp#controllers#init()
-  return split(system("find app/controllers -type f | sed 's_app/controllers/__'"), "\n")
+  return map(globpath('app/controllers/**', '*_controller.rb', 0, 1), 'fnamemodify(v:val, ":s?app/controllers/??:s?_controller.rb??")')
 endfunc
 
 function! ctrlp#controllers#accept(mode, str)
-  call ctrlp#acceptfile(a:mode, 'app/controllers/' . a:str)
+  call ctrlp#acceptfile(a:mode, 'app/controllers/' . a:str . '_controller.rb')
 endfunc
 
 let s:id = g:ctrlp_builtins + len(g:ctrlp_ext_vars)

--- a/autoload/ctrlp/libs.vim
+++ b/autoload/ctrlp/libs.vim
@@ -18,7 +18,7 @@ else
 endif
 
 function! ctrlp#libs#init()
-  return split(system("find lib -type f | sed 's_lib/__'"), "\n")
+  return map(globpath('lib/**', '*.*', 0, 1), 'fnamemodify(v:val, ":s?lib/??")')
 endfunc
 
 function! ctrlp#libs#accept(mode, str)

--- a/autoload/ctrlp/models.vim
+++ b/autoload/ctrlp/models.vim
@@ -18,11 +18,11 @@ else
 endif
 
 function! ctrlp#models#init()
-  return split(system("find app/models -type f | sed 's_app/models/__'"), "\n")
+  return map(globpath('app/models/**', '*.rb', 0, 1), 'fnamemodify(v:val, ":s?app/models/??:s?.rb??")')
 endfunc
 
 function! ctrlp#models#accept(mode, str)
-  call ctrlp#acceptfile(a:mode, 'app/models/' . a:str)
+  call ctrlp#acceptfile(a:mode, 'app/models/' . a:str . '.rb')
 endfunc
 
 let s:id = g:ctrlp_builtins + len(g:ctrlp_ext_vars)

--- a/autoload/ctrlp/specs.vim
+++ b/autoload/ctrlp/specs.vim
@@ -18,7 +18,7 @@ else
 endif
 
 function! ctrlp#specs#init()
-  return split(system("find spec -type f -iname \"*rb\" | sed 's_lib/__'"), "\n")
+  return map(globpath('spec/**', '*.rb', 0, 1), 'fnamemodify(v:val, ":s?lib/??")')
 endfunc
 
 function! ctrlp#specs#accept(mode, str)

--- a/autoload/ctrlp/views.vim
+++ b/autoload/ctrlp/views.vim
@@ -18,7 +18,7 @@ else
 endif
 
 function! ctrlp#views#init()
-  return split(system("find app/views -type f | sed 's_app/views/__'"), "\n")
+  return map(globpath('app/views/**', '*.*', 0, 1), 'fnamemodify(v:val, ":s?app/views/??")')
 endfunc
 
 function! ctrlp#views#accept(mode, str)


### PR DESCRIPTION
Use vim's builtin globpath function to get the files. This keeps hidden
files from being shown. Fixes #2